### PR TITLE
:pencil: Remove target from footer social links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,7 +7,7 @@
   <div class="row column">
     <ul class="social-icons">
       <li>
-        <a class="twitter" href="https://twitter.com/djangocon" target="_blank">
+        <a class="twitter" href="https://twitter.com/djangocon">
           <svg class="social-icon">
             <title>Twitter</title>
             <use xlink:href="#twitter-icon"></use>
@@ -15,7 +15,7 @@
         </a>
       </li>
       <li>
-        <a class="github" href="https://github.com/djangocon/" target="_blank">
+        <a class="github" href="https://github.com/djangocon/">
           <svg class="social-icon">
             <title>Github</title>
             <use xlink:href="#github-icon"></use>
@@ -23,7 +23,7 @@
         </a>
       </li>
       <li>
-        <a class="facebook" href="https://www.facebook.com/djangoconus/" target="_blank">
+        <a class="facebook" href="https://www.facebook.com/djangoconus/">
           <svg class="social-icon">
             <title>Facebook</title>
             <use xlink:href="#facebook-icon"></use>
@@ -33,7 +33,7 @@
 
       {% comment %}
       <li>
-        <a class="instagram" href="https://www.instagram.com/#TODO/" target="_blank">
+        <a class="instagram" href="https://www.instagram.com/#TODO/">
           <svg class="social-icon">
             <title>Instagram</title>
             <use xlink:href="#instagram-icon"></use>


### PR DESCRIPTION
Part of #13: 

 - [x] Social media icons in footer open in new window, inconsistent with other links