### PR TITLE
:pencil: Update copy

### DIFF
--- a/_pages/speaking-resources.md
+++ b/_pages/speaking-resources.md
@@ -7,27 +7,6 @@ description: Resources to support DjangoCon 2018 speakers
 ---
 
 {% comment %}
-##  Talks
-
-Length: (20-25 minutes) or (40-45 minutes)
-
-We are looking for original and interesting talks that can benefit the diverse interests of our audience. Don’t feel boxed into Django-centric themes; we also love talks about community, web development, user experience, and more. If you’re a first timer - don’t fret! We would love to be remembered as the conference where you started your speaking career.
-
-Here are some examples of what has been accepted over the last couple of years:
-
-* [DjangoCon US 2016 Talks](https://2016.djangocon.us/schedule/general-sessions/)
-* [DjangoCon US 2015 Talks](https://2015.djangocon.us/schedule/general-sessions/)
-
-##  Tutorials
-
-Length: ~3 - 3.5 hours
-
-We’re open to all kinds of ideas, especially ones we haven’t thought of! Technical tutorials tend to be more popular, but we welcome all topics. Tutorials can be targeted at any experience level, just be sure to indicate clearly what you expect your students to already know or have experience with{% comment %}in your proposal{% endcomment %}.
-{% endcomment %}
-
-{% comment %}Still unsure if you should submit? Not only will we cover your DjangoCon US ticket, but tutorials are compensated.{% endcomment %}
-
-{% comment %}
 <div class="row">
     <div class="column">
         <a class="button hollow theme-shakespeare" href="https://www.papercall.io/djangocon-us-2017">Apply today!</a>
@@ -35,13 +14,16 @@ We’re open to all kinds of ideas, especially ones we haven’t thought of! Tec
 </div>
 {% endcomment %}
 
+{% comment %}
 ## Information for Speakers
-* The Speaker Green Room will be in Willow II on Sunday-Wednesday. Please be in the Green Room at least 10 minutes before your talk to meet your session runner, who will escort you to your presentation room.  
+* The Speaker Green Room will be in Willow II on Sunday-Wednesday. Please be in the Green Room at least 10 minutes before your talk to meet your session runner, who will escort you to your presentation room.
 * The Quiet Room will be in Willow I on all conference days.
+{% endcomment %}
 
-## Need some help with your {% comment %}proposal or {% endcomment %}talk?
+{% comment %}
+## Need some help with your proposal?
 
-Presenters, regardless of experience, sometimes want a little help. If you’d like any help in {% comment %}proposing, {% endcomment %}preparing, or presenting your talk, some awesome members of our community have volunteered to be speaker mentors. A mentor is an experienced presenter who has volunteered to help other presenters. For first-time presenters, non-native English speakers, under-confident or uncertain speakers, or anyone who would just appreciate another set of eyes, our mentors will be here to help. You’ll get the best results by forming a relationship with one mentor, rather than contacting several.
+Presenters, regardless of experience, sometimes want a little help. If you’d like any help in proposing, preparing, or presenting your talk, some awesome members of our community have volunteered to be speaker mentors. A mentor is an experienced presenter who has volunteered to help other presenters. For first-time presenters, non-native English speakers, under-confident or uncertain speakers, or anyone who would just appreciate another set of eyes, our mentors will be here to help. You’ll get the best results by forming a relationship with one mentor, rather than contacting several.
 
 * [Adrienne Lowe](mailto:adrienne@djangoproject.com), DSF Director of Advancement, DjangoCon US and Django Girls Atlanta organizer, Your Django Story leader.
 * [Aisha Bello](mailto:aishabello2050@gmail.com), DjangoGirls Lagos organizer, a Python community enthusiastic with a lot of passion for women tech education in Africa.
@@ -52,6 +34,7 @@ Presenters, regardless of experience, sometimes want a little help. If you’d l
 * [Kojo Idrissa](mailto:kojo.idrissa@gmail.com), DjangoCon US organizer, Code Newbie, author.
 * [Dr Russell Keith-Magee](mailto:russell@keith-magee.com) is a 11 year veteran of the Django core team, and for 5 years, was President of the Django Software Foundation. He’s also the founder of the BeeWare project, developing GUI tools to support the development of Python software. When he’s not contributing to open source, he does freelance web development from his home in Perth, Western Australia.
 * [Sebastian Vetter](mailto:seb@roadsi.de), Vancouver Python Organizer, Senior Engineer @ Eventbase, Conference Enthusiast.
+{% endcomment %}
 
 ## Slide Guidelines
 

--- a/_pages/speaking.md
+++ b/_pages/speaking.md
@@ -8,13 +8,13 @@ description: Information about submitting a proposal to speak at DjangoCon US
 
 {% comment %}
 Our [Call for Proposals (CFP)](https://www.papercall.io/djangocon-us-2017) is now open! Submit your talk or tutorial proposal by April 10 ([AoE](https://time.is/compare/0000_11_Apr_2017_in_Anywhere_on_Earth)), and encourage your friends and colleagues to do the same.
-{% endcomment %}
 
-Need help with your talk?{% comment %}Need help with your proposal?{% endcomment %} We’ve got mentors and helpful tips on our [Speaker Resources](/speaking/speaker-resources/) page!
+Need help with your proposal? We’ve got mentors and helpful tips on our [Speaker Resources](/speaking/speaker-resources/) page!
+{% endcomment %}
 
 ## Why speak at DjangoCon US?
 
-- Presenters receive a free ticket to DjangoCon US! (Travel costs are not included{% comment %}, but speakers are encouraged to [apply for financial aid](/financial-aid/){% endcomment %}.)
+- Presenters receive a free ticket to DjangoCon US! (Travel costs are not included, but potential speakers are encouraged to [apply for financial aid](/financial-aid/).)
 - Professionally produced video of your talk published to our YouTube channel. (You may opt out of this.)
 - Professional photographer on hand to photograph your talk. (Also optional.)
 - Expose the Django community to new tools, practices, or ideas.
@@ -33,10 +33,32 @@ Need help with your talk?{% comment %}Need help with your proposal?{% endcomment
 </div>
 {% endcomment %}
 
-## Selection process
+## Proposing to DjangoCon US
 
-We’ll choose a selection of talks and tutorials that we feel add up to the most enjoyable and engaging program for our attendees. Volunteers from the Django community are invited to help us pick talks, and we rely heavily on them to help us select ones that are interesting and beneficial to our attendees. Community volunteers and conference organizers will all be reviewing anonymized submissions and collectively deciding which ones to accept. **Submissions for DjangoCon US 2017 are closed as of April 11, 2017 07:00 CDT.** We will notify those who have been accepted by **May 15, 2017**. We’ll publish the list of selected talks as soon as we can after the deadline.
+### Selection process
 
-## Lightning Talks ⚡️
+We’ll choose a selection of talks and tutorials that we feel add up to the most enjoyable and engaging program for our attendees. Volunteers from the Django community are invited to help us pick talks, and we rely heavily on them to help us select ones that are interesting and beneficial to our attendees. Community volunteers and conference organizers will review anonymized submissions and collectively decide which ones to accept. {% comment %}**Submissions for DjangoCon US 2017 are closed as of April 11, 2017 07:00 CDT.** We will notify those who have been accepted by **May 15, 2017**. We’ll publish the list of selected talks as soon as we can after the deadline. {% endcomment %}
 
-Not up for a full on talk/tutorial? Looking to give your first talk at a conference? Lightning talks are talks under 5 minutes with or without slides on almost any topic you want! Even if you’re nervous or shy, remember: it’s a MAXIMUM of 5 minutes. Sign-ups will happen **at the conference** and more details will be available there.
+### Talks
+
+Length: 20-25 minutes or 40-45 minutes
+
+We are looking for original and interesting talks that can benefit the diverse interests of our audience. Don’t feel boxed into Django-centric themes; we also love talks about community, web development, user experience, and more. If you’re a first timer - don’t fret! We would love to be remembered as the conference where you started your speaking career.
+
+Here are some examples of what has been accepted over the last couple of years:
+
+* [DjangoCon US 2017 Talks](https://2017.djangocon.us/talks/)
+* [DjangoCon US 2016 Talks](https://2016.djangocon.us/schedule/general-sessions/)
+
+### Tutorials
+
+Length: 3-3.5 hours
+
+We’re open to all kinds of ideas, especially ones we haven’t thought of! Technical tutorials tend to be more popular, but we welcome all topics. Tutorials can be targeted at any experience level, just be sure to indicate clearly what you expect your students to already know or have experience with.
+
+Still unsure if you should submit? Not only will we cover your DjangoCon US ticket, but tutorials are compensated.
+
+
+### Lightning Talks ⚡️
+
+Not up for a full-on talk or tutorial? Looking to give your first talk at a conference? Lightning talks are talks under 5 minutes with or without slides on almost any topic you want! Even if you’re nervous or shy, remember: it’s a **maximum** of 5 minutes. Sign-ups will happen at the conference.


### PR DESCRIPTION
Related to #13. Checks all boxes in `Speaking` and `Speaker Resources`, mostly through commenting out dates/speaker mentors. Lets us move forward with publishing the website while we're still gathering data. 

Also moved the talk/tutorial description to the `speaking/` page, since that's the one most potential speakers will go to first. 