### PR TITLE
:hammer: Update sponsor table

### DIFF
--- a/_pages/sponsors-information.md
+++ b/_pages/sponsors-information.md
@@ -49,6 +49,10 @@ The following a la carte offerings are available to increase visibility on site.
 | Logo on tote bags                                                                  | :heavy_check_mark:  |                     |                                                         |                    |                    |
 | 1 push notification to attendees during conference                                 | :heavy_check_mark:  |                     |                                                         |                    |                    |
 
+#### <del>Lanyard $2,000 (Limit 1)</del> SOLD!
+
+Lanyard sponsors enjoy having their logo visible to all attendees during the conference on the lanyards for the badges in which they’re sponsoring.
+
 #### Refreshments $2,000 (Limit 3)
 
 Conference organizers will recognize refreshment sponsors prior to each break and ensure your company’s name and logo are displayed on the refreshment stands.

--- a/_pages/sponsors-information.md
+++ b/_pages/sponsors-information.md
@@ -30,27 +30,24 @@ Django and the Python community at large pride themselves on their commitment to
 
 The following a la carte offerings are available to increase visibility on site.
 
-|                                                                                    | Bronze<br> $1,125  | Silver<br> $2,250  | Gold<br> $4,500                                         | Platinum<br> $9,000 | Diamond<br> $18,000 |
-| ---------------------------------------------------------------------------------- | :----------------: | :----------------: | :-----------------------------------------------------: | :-----------------: | :-----------------: |
-| Free Sponsor Registrations                                                         |         1          |         2          |                            4                            |          8          |          8          |
-| Diversity<br> (Can be added to any tier)                                           |     :moneybag:     |     :moneybag:     |                       :moneybag:                        |     :moneybag:      |     :moneybag:      |
-| Profile in conference app<br> (Logo & text description)                            | :white_check_mark: | :white_check_mark: |                   :white_check_mark:                    | :white_check_mark:  | :white_check_mark:  |
-| Tote bag insert<br> (Provided by Sponsor)                                          | :white_check_mark: | :white_check_mark: |                   :white_check_mark:                    | :white_check_mark:  | :white_check_mark:  |
-| Logo in video rotation                                                             | :white_check_mark: | :white_check_mark: |                   :white_check_mark:                    | :white_check_mark:  | :white_check_mark:  |
-| Name in press release and mailings                                                 | :white_check_mark: | :white_check_mark: |                   :white_check_mark:                    | :white_check_mark:  | :white_check_mark:  |
-| Sponsor link on website                                                            |    Bronze link     |    Silver link     |                        Gold link                        |    Platinum link    |     Preeminent      |
-| Social Media<br> Twitter & Facebook posts                                          |                    | :white_check_mark: |                   :white_check_mark:                    | :white_check_mark:  | :white_check_mark:  |
-| Booth Space                                                                        |                    |                    |                      Maximum of 12                      | :white_check_mark:  |     Preeminent      |
-| Logo on a banner carousel in conference app                                        |                    | :white_check_mark: |                   :white_check_mark:                    | :white_check_mark:  | :white_check_mark:  |
-| Banner Stands for Keynote and Speaking Rooms<br> (Max of two; provided by sponsor) |                    |                    | Keynote Room<br> - Speaking Room<br> (Space permitting) | :white_check_mark:  |     Preeminent      |
-| Logo on conference app menu                                                        |                    |                    |                                                         | :white_check_mark:  | :white_check_mark:  |
-| Logo featured in post conference videos                                            |                    |                    |                                                         | :white_check_mark:  | :white_check_mark:  |
-| Logo on tote bags                                                                  |                    |                    |                                                         |                     | :white_check_mark:  |
-| 1 push notification to attendees during conference                                 |                    |                    |                                                         |                     | :white_check_mark:  |
-
-#### Lanyard $3,000 (Limit 1)
-
-Lanyard sponsors enjoy having their logo visible to all attendees during the conference on the lanyards for the badges in which they’re sponsoring.
+|                                                                                    | Diamond<br> $18,000 | Platinum<br> $9,000 | Gold<br> $4,500                                         | Silver<br> $2,250  | Bronze<br> $1,125  |
+| ---------------------------------------------------------------------------------- | :-----------------: | :-----------------: | :-----------------------------------------------------: | :----------------: | :----------------: |
+| Free Sponsor Registrations                                                         |          8          |          8          |                            4                            |         2          |         1          |
+| 10% Discount on extra conference tickets (corporate rate)                          |          8          |          8          |                            4                            |         2          |         1          |
+| Diversity<br> (Can be added to any tier)                                           |     :moneybag:      |     :moneybag:      |                       :moneybag:                        |     :moneybag:     |     :moneybag:     |
+| Profile in conference app<br> (Logo & text description)                            | :heavy_check_mark:  | :heavy_check_mark:  |                   :heavy_check_mark:                    | :heavy_check_mark: | :heavy_check_mark: |
+| Tote bag insert<br> (Provided by Sponsor)                                          | :heavy_check_mark:  | :heavy_check_mark:  |                   :heavy_check_mark:                    | :heavy_check_mark: | :heavy_check_mark: |
+| Logo in video rotation                                                             | :heavy_check_mark:  | :heavy_check_mark:  |                   :heavy_check_mark:                    | :heavy_check_mark: | :heavy_check_mark: |
+| Name in press release and mailings                                                 | :heavy_check_mark:  | :heavy_check_mark:  |                   :heavy_check_mark:                    | :heavy_check_mark: | :heavy_check_mark: |
+| Sponsor link on website                                                            | :heavy_check_mark:  | :heavy_check_mark:  |                   :heavy_check_mark:                    | :heavy_check_mark: | :heavy_check_mark: |
+| Social Media<br> Twitter & Facebook posts                                          | :heavy_check_mark:  | :heavy_check_mark:  |                   :heavy_check_mark:                    | :heavy_check_mark: |                    |
+| Booth Space                                                                        | :heavy_check_mark:  | :heavy_check_mark:  |            :heavy_check_mark: <br>Space permitting      |                    |                    |
+| Logo on a banner carousel in conference app                                        | :heavy_check_mark:  | :heavy_check_mark:  |                   :heavy_check_mark:                    | :heavy_check_mark: |                    |
+| Banner Stands for Keynote and Speaking Rooms<br> (Max of two; provided by sponsor) | :heavy_check_mark:  | :heavy_check_mark:  |            :heavy_check_mark: <br>Space permitting      |                    |                    |
+| Logo on conference app menu                                                        | :heavy_check_mark:  | :heavy_check_mark:  |                                                         |                    |                    |
+| Logo featured in post conference videos                                            | :heavy_check_mark:  | :heavy_check_mark:  |                         $1,000                          |      $1,000        |      $1,000        |
+| Logo on tote bags                                                                  | :heavy_check_mark:  |                     |                                                         |                    |                    |
+| 1 push notification to attendees during conference                                 | :heavy_check_mark:  |                     |                                                         |                    |                    |
 
 #### Refreshments $2,000 (Limit 3)
 
@@ -69,7 +66,7 @@ Interested in another sponsorship opportunity? Get in touch and we’ll do our b
 
 ## Interested in Sponsoring?
 
-<strong><a href="mailto:sponsors@djangocon.us">Send us an email!</a></strong> We're here to help make the process of becoming a sponsor as easy as we can!
+<strong><a href="mailto:{{site.sponsors_email}}">Send us an email!</a></strong> We're here to help make the process of becoming a sponsor as easy as we can!
 
 {% comment %}
 #### Booth info


### PR DESCRIPTION
Related to #13. cc @daheats 

- Replaced hard-coded email with email variable 
- Deleted lanyard sponsorship because REVSYS bought that (according to Trello) 
- Reverses column order to lead with Diamond and end with Bronze 
- Updated offerings based on [prospectus](https://drive.google.com/file/d/12nkZ93LjEqVMwk-PZ9Ka_uQa99_1ZOYu/preview) 
- Replaced checkmark emoji due to how the emoji renders with the new design 
- Replaces words like "preeminent" in the table with emoji to simplify the table (for higher-tier sponsors we are likely having closer conversations with them anyway) 

Screenshot of **new** table: 
![screen shot 2018-03-14 at 4 15 28 pm](https://user-images.githubusercontent.com/2286304/37435979-f77bbb90-27a2-11e8-8c08-b818a0ac2ccc.png)

Screenshot of **old** table: 
<img width="954" alt="screen shot 2018-03-14 at 4 16 10 pm" src="https://user-images.githubusercontent.com/2286304/37436002-10a5fb4e-27a3-11e8-8509-caaf32857b84.png">

