### PR TITLE
Update Katie's mentor description

### DIFF
--- a/_pages/speaking-resources.md
+++ b/_pages/speaking-resources.md
@@ -29,7 +29,7 @@ Presenters, regardless of experience, sometimes want a little help. If you’d l
 * [Frank Wiles](mailto:frank@revsys.com), President of the Board, Django Software Foundation, Founder, REVSYS.
 * [Josue Balandrano Coronel](mailto:josuebc@defna.org), DEFNA board member and software engineer at the Texas Advanced Computing Center.
 * [Katia Lira](mailto:katialira@defna.org), Full-stack dev and DEFNA Board Member. I gave a tutorial last year overcoming my nerves and fear and you can too!
-* [Katie McLaughlin](mailto:katie@glasnt.com), PyCon AU and DjangoCon AU Organiser, PSF Contributing Member.
+* [Katie McLaughlin](mailto:katie@glasnt.com), PyCon AU and DjangoCon AU Organiser, DSF Director, PSF Contributing Member.
 * [Philip James](mailto:pjj@philipjohnjames.com), Core Contributor to the BeeWare project and Senior Software Engineer at Patreon. Philip has spoken at a number of DjangoCons and PyCons around the world.
 * [Dr. Russell Keith-Magee](mailto:russell@keith-magee.com), 11 year veteran of the Django core team, former President of the Django Software Foundation, founder of the BeeWare project, developing GUI tools to support the development of Python software. When he’s not contributing to open source, he does freelance web development from his home in Perth, Western Australia.
 * [Sebastian Vetter](mailto:seb@roadsi.de), Vancouver Python Organizer, Senior Engineer @ Eventbase, Conference Enthusiast.


### PR DESCRIPTION
Updates #61 

Changes proposed in this PR:
 - Lists me as a DSF director ✨

(Original description was rolled over from 2017, so the DSF listing is new and shiny, and might be helpful for people looking for mentors)