### PR TITLE
:hammer: Add finaid and CFP links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -89,7 +89,8 @@ visa_email: "visas@djangocon.us"
 
 # Our DjangoCon US links
 sponsorship_prospectus: "https://drive.google.com/file/d/1gPE-iGJVJjglf-1o5wVV_qnfVgVt6Gb-/view"
-financial_aid_application: "/financial-aid"
+financial_aid_application: "https://docs.google.com/forms/d/e/1FAIpQLSfqOQJNXDSftszH5Ar_LQT6Y0IcvuRUaXTC9ERS6h6PTKsvHg/viewform"
+cfp_application: "https://www.papercall.io/djangocon-us-2018"
 hotel_reservation_link: "http://www.marriott.com/meeting-event-hotels/group-corporate-travel/groupCorp.mi?resLinkData=DjangoCon%20US%202018%5Esanmv%60djcdjca%60169.00%60USD%60false%604%6010/13/18%6010/20/18%609/13/18&app=resvlink&stop_mobi=yes"
 ticket_link: "/tickets/"
 slack_link: ""

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -5,9 +5,7 @@
     <li><a href="/tickets/">Tickets</a></li>
     <li><a href="/faq/">FAQ</a></li>
     <li><a href="/conduct/">Code of Conduct</a></li>
-    {% comment %}
     <li><a href="/financial-aid/">Financial Aid</a></li>
-    {% endcomment %}
     <li><a href="/why-djangocon-us/">Why DjangoCon US?</a></li>
     <li><a href="/organizers/">Organizers</a></li>
   </ul>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -106,7 +106,7 @@ layout: base
           />
         <div class="card-section">
           <h3 class="card-title">Submit a Proposal</h3>
-          <p>Get more out of your DjangoCon US experience by presenting! Our CFP will open soon and in the meantime, check our <strong><a href="/speaking/">speaking</a></strong> page for more information.</p>
+          <p>Get more out of your DjangoCon US experience by presenting! Our <strong><a href="{{site.cfp_application}}">Call for Proposals</a></strong> is open until June 4, 2018. We can't wait to see your proposals!</p>
         </div>
       </div>
     </div>

--- a/_pages/financial-aid.md
+++ b/_pages/financial-aid.md
@@ -13,7 +13,6 @@ description: |
 
 As part of our commitment to diversity, we are thrilled to announce that we will be supporting individuals who need financial assistance to attend DjangoCon US.
 
-{% comment %}
 <div class="row column">
     <div class="medium-5 medium-centered column">
         <div class="button-group expanded">
@@ -21,7 +20,6 @@ As part of our commitment to diversity, we are thrilled to announce that we will
         </div>
     </div>
 </div>
-{% endcomment %}
 
 {% comment %}
 [Django Events Foundation North America (DEFNA)](http://www.defna.org/), [The Django Software Foundation](https://www.djangoproject.com/foundation/), and the [Python Software Foundation](https://www.python.org/psf/) have each donated to help meet the cost of tickets, travel, and accommodation for attendees who need financial support. If you will not be able to attend DjangoCon US without financial help, we strongly encourage you to apply for financial aid.{% endcomment %}

--- a/_pages/speaking-resources.md
+++ b/_pages/speaking-resources.md
@@ -7,14 +7,6 @@ description: Resources to support DjangoCon 2018 speakers
 ---
 
 {% comment %}
-<div class="row">
-    <div class="column">
-        <a class="button hollow theme-shakespeare" href="https://www.papercall.io/djangocon-us-2017">Apply today!</a>
-    </div>
-</div>
-{% endcomment %}
-
-{% comment %}
 ## Information for Speakers
 * The Speaker Green Room will be in Willow II on Sunday-Wednesday. Please be in the Green Room at least 10 minutes before your talk to meet your session runner, who will escort you to your presentation room.
 * The Quiet Room will be in Willow I on all conference days.
@@ -37,6 +29,15 @@ Presenters, regardless of experience, sometimes want a little help. If you’d l
 * [Aisha Bello](mailto:aishabello2050@gmail.com), DjangoGirls Lagos organizer, a Python community enthusiastic with a lot of passion for women tech education in Africa.
 * [Kojo Idrissa](mailto:kojo.idrissa@gmail.com), DjangoCon US organizer, Code Newbie, author.
 {% endcomment %}
+
+<div class="row column v-pad-top">
+    <div class="medium-5 medium-centered column">
+        <div class="button-group expanded">
+            <a class="button hollow theme-violetred" href="{{site.cfp_application}}">Submit a Talk</a>
+            <a class="button hollow theme-willow" href="{{site.financial_aid_application}}">Apply for Financial Aid</a>
+        </div>
+    </div>
+</div>
 
 ## Slide Guidelines
 

--- a/_pages/speaking.md
+++ b/_pages/speaking.md
@@ -6,15 +6,13 @@ permalink: /speaking/
 description: Information about submitting a proposal to speak at DjangoCon US
 ---
 
-{% comment %}
-Our [Call for Proposals (CFP)](https://www.papercall.io/djangocon-us-2017) is now open! Submit your talk or tutorial proposal by April 10 ([AoE](https://time.is/compare/0000_11_Apr_2017_in_Anywhere_on_Earth)), and encourage your friends and colleagues to do the same.
+Our [Call for Proposals]({{site.cfp_application}}) (CFP) is now open! Submit your talk or tutorial proposal by June 4 ([AoE](https://time.is/compare/0000_03_Jun_2018_in_Anywhere_on_Earth)), and encourage your friends and colleagues to do the same.
 
 Need help with your proposal? We’ve got mentors and helpful tips on our [Speaker Resources](/speaking/speaker-resources/) page!
-{% endcomment %}
 
 ## Why speak at DjangoCon US?
 
-- Presenters receive a free ticket to DjangoCon US! (Travel costs are not included, but potential speakers are encouraged to apply for financial aid {% comment %}[apply for financial aid](/financial-aid/){% endcomment %}.)
+- Presenters receive a free ticket to DjangoCon US! (Travel costs are not included, but potential speakers are encouraged [apply for financial aid]({{site.financial_aid_application}}).)
 - Professionally produced video of your talk published to our YouTube channel. (You may opt out of this.)
 - Professional photographer on hand to photograph your talk. (Also optional.)
 - Expose the Django community to new tools, practices, or ideas.
@@ -22,16 +20,14 @@ Need help with your proposal? We’ve got mentors and helpful tips on our [Speak
 - Share your discoveries with a large audience.
 - Give back to the Django community!
 
-{% comment %}
 <div class="row column v-pad-top">
     <div class="medium-5 medium-centered column">
         <div class="button-group expanded">
-            <a class="button hollow theme-violetred" href="https://www.papercall.io/djangocon-us-2017">Submit a Talk</a>
-            <a class="button hollow theme-willow" href="/financial-aid/">Apply for Financial Aid</a>
+            <a class="button hollow theme-violetred" href="{{site.cfp_application}}">Submit a Talk</a>
+            <a class="button hollow theme-willow" href="{{site.financial_aid_application}}">Apply for Financial Aid</a>
         </div>
     </div>
 </div>
-{% endcomment %}
 
 ## Proposing to DjangoCon US
 


### PR DESCRIPTION
Closes # 81.

Changes proposed in this PR:

- Adds financial aid and CFP application links to the config file 
- Enables financial aid page in navigation
- Adds CFP link to homepage 
- Adds finaid app button to finaid page 
- Adds CFP and finaid app buttons to speaker resources and speaking pages 
- Adds CFP open text to speaking page 
