### PR TITLE
Remove cfp

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -107,13 +107,13 @@ layout: base
       {% comment %} TODO: Contrast {% endcomment %}
       <div class="card card-theme-eminence">
         <img
-          src="{{ "/static/img/megaphone.svg" | relative_url }}"
+          src="{{ "/static/img/program.svg" | relative_url }}"
           alt="A megaphone producing a loud sound"
           class="card-icon"
           />
         <div class="card-section">
-          <h3 class="card-title">Submit a Proposal</h3>
-          <p>Get more out of your DjangoCon US experience by presenting! Our <strong><a href="{{site.cfp_application}}">Call for Proposals</a></strong> is open until June 3, 2018. We can't wait to see your proposals!</p>
+          <h3 class="card-title">Get Your Ticket</h3>
+          <p>Tickets are <a href="{{site.ticket_link}}">still available</a>! Don't miss out on your chance to join us in sunny San Diego!</p>
         </div>
       </div>
     </div>

--- a/_pages/financial-aid.md
+++ b/_pages/financial-aid.md
@@ -9,24 +9,7 @@ description: |
     As part of our commitment to diversity, we are thrilled to announce that we will be supporting individuals who need financial assistance to attend DjangoCon US
 ---
 
-## Apply for Financial Aid!
-
-As part of our commitment to diversity, we are thrilled to announce that we will be supporting individuals who need financial assistance to attend DjangoCon US.
-
-<div class="row column">
-    <div class="medium-5 medium-centered column">
-        <div class="button-group expanded">
-            <a class="button hollow theme-shakespeare" href="{{ site.financial_aid_application }}">Apply for Financial Aid</a>
-        </div>
-    </div>
-</div>
-
-{% comment %}
-[Django Events Foundation North America (DEFNA)](http://www.defna.org/), [The Django Software Foundation](https://www.djangoproject.com/foundation/), and the [Python Software Foundation](https://www.python.org/psf/) have each donated to help meet the cost of tickets, travel, and accommodation for attendees who need financial support. If you will not be able to attend DjangoCon US without financial help, we strongly encourage you to apply for financial aid.{% endcomment %}
-
-In addition, speakers will be provided with free conference tickets.
-
-You can apply for financial aid by filling out [the application]({{ site.financial_aid_application }}). You’ll need to provide your name, the amount you’re requesting, and some information about why you’re requesting funding. Applications need to be submitted by June 3rd in order to be considered. Decision notifications will be sent by July 9th, 2018.
+Our financial aid application is now closed. Decision notifications will be sent by July 9th, 2018.
 
 If you have any questions, feel free to reach out to the financial aid team at [{{ site.financial_aid_email }}](mailto:{{ site.financial_aid_email }}).
 

--- a/_pages/speaking-resources.md
+++ b/_pages/speaking-resources.md
@@ -17,8 +17,9 @@ description: Resources to support DjangoCon 2018 speakers
 Presenters, regardless of experience, sometimes want a little help. If you’d like any help in proposing, preparing, or presenting your talk, some awesome members of our community have volunteered to be speaker mentors. A mentor is an experienced presenter who has volunteered to help other presenters. For first-time presenters, non-native English speakers, under-confident or uncertain speakers, or anyone who would just appreciate another set of eyes, our mentors will be here to help. You’ll get the best results by forming a relationship with one mentor, rather than contacting several.
 
 * [Adrienne Lowe](mailto:adrienne@djangoproject.com), DSF Director of Advancement, DjangoCon US and Django Girls Atlanta organizer.
-* [Anna Ossowski](mailto: annabell.ossowski@gmail.com), Developer Relations at Elastic, speaker, mentor, PyCon Open Spaces advisor, DjangoCon Diversity Chair, Django Girls Omaha and San Francisco organizer, PyLadies Remote co-lead.
+* [Anna Ossowski](mailto:annabell.ossowski@gmail.com), Developer Relations at Elastic, speaker, mentor, PyCon Open Spaces advisor, DjangoCon Diversity Chair, Django Girls Omaha and San Francisco organizer, PyLadies Remote co-lead.
 * [Frank Wiles](mailto:frank@revsys.com), President of the Board, Django Software Foundation, Founder, REVSYS.
+* [Jacinda Shelly](mailto:jacinda.shelly@gmail.com). Jacinda nurtured an early love of sharing knowledge by recording books on cassette for her brothers to listen to as bedtime stories. She has spoken at multiple technical conferences, including PyCon and DjangoCon US. She works for Doctor On Demand and lives in San Francisco with her husband and daughter.
 * [Josue Balandrano Coronel](mailto:josuebc@defna.org), DEFNA board member and software engineer at the Texas Advanced Computing Center.
 * [Katia Lira](mailto:katialira@defna.org), Full-stack dev and DEFNA Board Member. I gave a tutorial last year overcoming my nerves and fear and you can too!
 * [Katie McLaughlin](mailto:katie@glasnt.com), PyCon AU and DjangoCon AU Organiser, DSF Director, PSF Contributing Member.
@@ -30,15 +31,6 @@ Presenters, regardless of experience, sometimes want a little help. If you’d l
 * [Aisha Bello](mailto:aishabello2050@gmail.com), DjangoGirls Lagos organizer, a Python community enthusiastic with a lot of passion for women tech education in Africa.
 * [Kojo Idrissa](mailto:kojo.idrissa@gmail.com), DjangoCon US organizer, Code Newbie, author.
 {% endcomment %}
-
-<div class="row column v-pad-top">
-    <div class="medium-5 medium-centered column">
-        <div class="button-group expanded">
-            <a class="button hollow theme-violetred" href="{{site.cfp_application}}">Submit a Talk</a>
-            <a class="button hollow theme-willow" href="{{site.financial_aid_application}}">Apply for Financial Aid</a>
-        </div>
-    </div>
-</div>
 
 ## Slide Guidelines
 

--- a/_pages/speaking.md
+++ b/_pages/speaking.md
@@ -6,9 +6,7 @@ permalink: /speaking/
 description: Information about submitting a proposal to speak at DjangoCon US
 ---
 
-Our [Call for Proposals]({{site.cfp_application}}) (CFP) is now open! Submit your talk or tutorial proposal by June 3 ([AoE](https://time.is/compare/0000_03_Jun_2018_in_Anywhere_on_Earth)), and encourage your friends and colleagues to do the same. Decision notifications will be sent by July 9th, 2018.
-
-Need help with your proposal? We’ve got mentors and helpful tips on our [Speaker Resources](/speaking/speaker-resources/) page!
+Our Call for Proposals is now closed. Decision notifications will be sent by July 9th, 2018.
 
 ## Why speak at DjangoCon US?
 
@@ -19,15 +17,6 @@ Need help with your proposal? We’ve got mentors and helpful tips on our [Speak
 - Expand your technical, professional, and personal networks.
 - Share your discoveries with a large audience.
 - Give back to the Django community!
-
-<div class="row column v-pad-top">
-    <div class="medium-5 medium-centered column">
-        <div class="button-group expanded">
-            <a class="button hollow theme-violetred" href="{{site.cfp_application}}">Submit a Talk</a>
-            <a class="button hollow theme-willow" href="{{site.financial_aid_application}}">Apply for Financial Aid</a>
-        </div>
-    </div>
-</div>
 
 ## Proposing to DjangoCon US
 


### PR DESCRIPTION
Closes #104 .

Changes proposed in this PR:

- Remove CFP and financial aid app links from all pages.
- Edit text to "Our [application] is now closed" 
- Add Jacinda Shelly as speaker mentor. 
