### PR TITLE
:pencil: Add  financial aid notification date

### DIFF
--- a/_pages/financial-aid.md
+++ b/_pages/financial-aid.md
@@ -13,11 +13,19 @@ Our financial aid application is now closed. Decision notifications will be sent
 
 If you have any questions, feel free to reach out to the financial aid team at [{{ site.financial_aid_email }}](mailto:{{ site.financial_aid_email }}).
 
+<br>
+
 ## Diversity Sponsorships
 
 Your organization can help increase diversity at DjangoCon US by contributing to the Financial Aid fund. Please check out our [sponsorship information page](/sponsors/information/) for more information.
 
+<br>
+
 ## Frequently Asked Questions
+
+### When will I find out whether I've received financial aid?
+
+We will let you know by July 9th, 2018.
 
 ### Do I need to be a speaker, first time attendee, or a member of an underrepresented group to receive aid?
 

--- a/_pages/speaking.md
+++ b/_pages/speaking.md
@@ -10,7 +10,7 @@ Our Call for Proposals is now closed. Decision notifications will be sent by Jul
 
 ## Why speak at DjangoCon US?
 
-- Presenters receive a free ticket to DjangoCon US! (Travel costs are not included, but potential speakers are encouraged [apply for financial aid]({{site.financial_aid_application}}).)
+- Presenters receive a free ticket to DjangoCon US! (Travel costs are not included, but potential speakers were encouraged apply for financial aid. Financial aid decision notifications will be sent by July 9th, 2018.)
 - Professionally produced video of your talk published to our YouTube channel. (You may opt out of this.)
 - Professional photographer on hand to photograph your talk. (Also optional.)
 - Expose the Django community to new tools, practices, or ideas.
@@ -22,7 +22,7 @@ Our Call for Proposals is now closed. Decision notifications will be sent by Jul
 
 ### Selection process
 
-We’ll choose a selection of talks and tutorials that we feel add up to the most enjoyable and engaging program for our attendees. Volunteers from the Django community are invited to help us pick talks, and we rely heavily on them to help us select ones that are interesting and beneficial to our attendees. Community volunteers and conference organizers will review anonymized submissions and collectively decide which ones to accept.
+We’ll choose a selection of talks and tutorials that we feel add up to the most enjoyable and engaging program for our attendees. Volunteers from the Django community are invited to help us pick talks, and we rely heavily on them to help us select ones that are interesting and beneficial to our attendees. Community volunteers and conference organizers will review anonymized submissions and collectively decide which ones to accept. We will notify you by July 9th, 2018 of whether your proposal was accepted.
 
 ### Talks (October 15th, 16th, &amp; 17th)
 


### PR DESCRIPTION
Closes #103 

Changes proposed in this PR:

- Adds "When will I find out" FAQ to financial aid page (notification date is already in the top paragraph, but in case it's missed) 
- Adds financial aid notification date to speaker info page as well 
- Adds another statement of proposal notification date to the CFP page. 
- Adds some whitespace to the financial aid page so the text doesn't run together quite as much, making it easier to see the FAQ 
