### PR TITLE
:fire: Remove childcare survey

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -24,12 +24,6 @@ layout: base
           <a class="button hollow theme-willow" href="http://eepurl.com/bpvu2f">Subscribe to our mailing list</a>
         </div>
       </div>
-      <div class="row">
-        <div class="medium-8 column medium-centered text-center">
-          <a class="button hollow theme-shakespeare" href="https://goo.gl/forms/XVWe7R3Qb7ujQO3T2">Take our childcare survey</a>
-        </div>
-      </div>
-
 
     </div>
     <div class="column small-12 medium-6 text-center">

--- a/_posts/2018-06-28-childcare-survey.md
+++ b/_posts/2018-06-28-childcare-survey.md
@@ -11,16 +11,8 @@ We’re always trying to make DjangoCon US more inclusive and welcoming to our a
 
 As we get ready for DjangoCon US 2018, we want to make sure we’re best serving our community, so we’re running a short survey on childcare availability at DjangoCon US.
 
-**Please [fill out the survey](https://goo.gl/forms/XVWe7R3Qb7ujQO3T2) by July 10.**
+Update: The survey is now closed. ~~Please [fill out the survey](https://goo.gl/forms/XVWe7R3Qb7ujQO3T2) by July 10.~~
 
 Your responses will be completely anonymous, and we really want to hear what you think. Your answers help us make DjangoCon US better!
 
 We hope to see you in San Diego!
-
-<div class="row column">
-    <div class="medium-5 medium-left column">
-        <div class="button-group expanded">
-            <a class="button hollow theme-willow" href="https://goo.gl/forms/XVWe7R3Qb7ujQO3T2">Fill out the childcare survey</a>
-        </div>
-    </div>
-</div>


### PR DESCRIPTION
Changes proposed in this PR:

- Remove link to childcare survey from home page 
- Update blog post to reflect that survey is now closed. 
