### PR TITLE
Fix/schedule links

### DIFF
--- a/_includes/schedule-session.html
+++ b/_includes/schedule-session.html
@@ -14,7 +14,7 @@
     {% if post.permalink %}
       <a href="{{ post.permalink }}" class="event-content">
     {% else %}
-      <article class="event">
+      <section class="event">
     {% endif %}
 
         {% if post.title %}
@@ -43,7 +43,7 @@
     {% if post.permalink %}
       </a>
     {% else %}
-      </article>
+      </section>
     {% endif %}
   {% endunless %}
 </li>

--- a/_includes/schedule-session.html
+++ b/_includes/schedule-session.html
@@ -11,29 +11,39 @@
 
   ">
   {% unless post.room == 'filler' %}
-    <a href="{{ post.permalink }}" class="event-content">
-      {% if post.title %}
-        <h3 class="event-title">{{ post.title }}</h3>
-      {% endif %}
-      {% if post.difficulty %}
-        <span class="label" aria-label="Audience level:">{{ post.difficulty }}</span>
-      {% endif %}
-      {% if post.room %}
-        <p class="location">{{ post.room }}</p>
-      {% endif %}
-      {% if post.presenters %}
-        {% for presenter in post.presenters %}
-        <p class="event-byline">
-          {% if presenter.photo_url != blank %}
-          <img
-            class="avatar"
-            src="{{ presenter.photo_url }}"
-            alt="Photo of {{ presenter.presenters }}" />
-          {% endif %}
-          {{ presenter.name }}
-        </p>
-        {% endfor %}
-      {% endif %}
-    </a>
+    {% if post.permalink %}
+      <a href="{{ post.permalink }}" class="event-content">
+    {% else %}
+      <article class="event">
+    {% endif %}
+
+        {% if post.title %}
+          <h3 class="event-title">{{ post.title }}</h3>
+        {% endif %}
+        {% if post.difficulty %}
+          <span class="label" aria-label="Audience level:">{{ post.difficulty }}</span>
+        {% endif %}
+        {% if post.room %}
+          <p class="location">{{ post.room }}</p>
+        {% endif %}
+        {% if post.presenters %}
+          {% for presenter in post.presenters %}
+          <p class="event-byline">
+            {% if presenter.photo_url != blank %}
+            <img
+              class="avatar"
+              src="{{ presenter.photo_url }}"
+              alt="Photo of {{ presenter.presenters }}" />
+            {% endif %}
+            {{ presenter.name }}
+          </p>
+          {% endfor %}
+        {% endif %}
+
+    {% if post.permalink %}
+      </a>
+    {% else %}
+      </article>
+    {% endif %}
   {% endunless %}
 </li>


### PR DESCRIPTION
The Schedule page was experiencing an issue where sessions that had rooms assigned, but no permalink, were appearing linkable. This fixes that by checking for the presence of a permalink.

Changes proposed in this PR:

- Wraps the anchor tag in a conditional. If no permalink is found, replace the anchor with a section tag. Otherwise, show the link.

My experience locally with this fix:

<img width="1254" alt="screenshot 2018-09-10 17 07 34" src="https://user-images.githubusercontent.com/84750/45324698-e3c74800-b51c-11e8-8943-d99ea6e6b626.png">
