### PR TITLE
Fixes linking to Lincoln Loop

### DIFF
--- a/_sponsors/2018-03-19-lincoln-loop.md
+++ b/_sponsors/2018-03-19-lincoln-loop.md
@@ -5,7 +5,7 @@ level: 'Gold'
 name: "Lincoln Loop"
 logo: "/static/img/sponsors/ll_logo_landscape_color.svg"
 logo_orientation: "landscape"
-url: "https://lincolnloop.com/"
+url_target: "https://lincolnloop.com/"
 url_friendly: "lincolnloop.com"
 description: |
     Lincoln Loop is a full-service software development agency specializing in Python and Django development for web and mobile. Since 2007 our emphasis on quality in an agile environment has helped numerous startups and high-traffic sites grow their businesses. In addition to rock solid Python powered backends, Lincoln Loop provides user experience, deployment, and real-time application development with JavaScript.


### PR DESCRIPTION
@moniquemurphy noticed that the link to Lincoln Loop's website was broken on the sponsor page. This was due to a mix up in the Markdown file for LL.

Changes proposed in this PR:

- Uses `url_target` instead of `url` in LL's Markdown file

Chrome hover on the link:

![screenshot 2018-09-11 15 29 57](https://user-images.githubusercontent.com/84750/45382860-95c34a80-b5d7-11e8-99a8-37657b25ba6c.png)
