### PR TITLE
:pencil: Capitalize all words in heading

### DIFF
--- a/_layouts/session-details.html
+++ b/_layouts/session-details.html
@@ -55,7 +55,7 @@ layout: base
         {% include youtube-embed.html id=youtube_id %}
       {% endif %}
 
-      <h2>About This {{ page.category | capitalize }}</h2>
+      <h2 style="text-transform:capitalize;">About This {{ page.category | capitalize }}</h2>
       {{ content }}
     </div>
     <div class="column medium-4">


### PR DESCRIPTION
Changes proposed in this PR:

- Makes sure all words in talk/tutorial/event heading are capitalized. (Correct "About This Social event" --> "About This Social Event") 
