### PR TITLE
📝 Add a slew of slides links in talk schedule

### DIFF
--- a/_schedule/talks/2018-10-15-12-20-t1-herding-cats-with-django-technical-and.md
+++ b/_schedule/talks/2018-10-15-12-20-t1-herding-cats-with-django-technical-and.md
@@ -47,7 +47,7 @@ presenters:
 published: true
 room: 'Salon F-H'
 sitemap: true
-slides_url: ''
+slides_url: 'https://www.slideshare.net/saharabeara/herding-cats-with-django'
 summary: ''
 title: 'Herding Cats with Django: Technical and social tools to incentivize participation'
 track: t1

--- a/_schedule/talks/2018-10-15-14-20-t1-transfer-those-skills-how-to-identify.md
+++ b/_schedule/talks/2018-10-15-14-20-t1-transfer-those-skills-how-to-identify.md
@@ -43,7 +43,7 @@ presenters:
 published: true
 room: 'Salon F-H'
 sitemap: true
-slides_url: ''
+slides_url: 'https://speakerdeck.com/rebekahpost/transfer-those-skills'
 summary: ''
 title: 'Transfer those Skills! How to Identify, Communicate, and Sell your Transferable
   Skills when Switching Careers '

--- a/_schedule/talks/2018-10-15-15-10-t0-building-workflows-with-celery.md
+++ b/_schedule/talks/2018-10-15-15-10-t0-building-workflows-with-celery.md
@@ -27,7 +27,7 @@ presenters:
 published: true
 room: 'Salon A-E'
 sitemap: true
-slides_url: ''
+slides_url: 'https://docs.google.com/presentation/d/1muDz5nzOTbXTi8rQX4n7B-8bQOMPUry5nJK0xfY8jWM/edit'
 summary: ''
 title: Building Workflows With Celery
 track: t0

--- a/_schedule/talks/2018-10-15-16-10-t0-elasticsearch-accelerating-the-django.md
+++ b/_schedule/talks/2018-10-15-16-10-t0-elasticsearch-accelerating-the-django.md
@@ -26,7 +26,7 @@ presenters:
 published: true
 room: 'Salon A-E'
 sitemap: true
-slides_url: ''
+slides_url: 'http://www.katekligman.com/2018/10/elasticsearch-accelerating-the-django-admin-slides/'
 summary: ''
 title: 'Elasticsearch: Accelerating the Django Admin'
 track: t0

--- a/_schedule/talks/2018-10-16-10-15-keynote-with-anna-makarudze.md
+++ b/_schedule/talks/2018-10-16-10-15-keynote-with-anna-makarudze.md
@@ -17,7 +17,7 @@ presenters:
   website: http://amakarudze.pythonanywhere.com/
 room: Salon A-E
 sitemap: true
-slides_url: null
+slides_url: 'https://speakerdeck.com/amakarudze/my-journey-with-code'
 talk_slot: full
 title: Keynote with Anna Makarudze
 video_url: null

--- a/_schedule/talks/2018-10-16-11-30-t1-finally-understand-authentication-in.md
+++ b/_schedule/talks/2018-10-16-11-30-t1-finally-understand-authentication-in.md
@@ -24,7 +24,7 @@ presenters:
 published: true
 room: 'Salon F-H'
 sitemap: true
-slides_url: ''
+slides_url: 'https://tinyurl.com/djangocon2018-rest-auth'
 summary: ''
 title: 'Finally Understand Authentication in Django REST Framework '
 track: t1

--- a/_schedule/talks/2018-10-16-14-20-t0-javascript-for-python-developers.md
+++ b/_schedule/talks/2018-10-16-14-20-t0-javascript-for-python-developers.md
@@ -23,7 +23,7 @@ presenters:
 published: true
 room: 'Salon A-E'
 sitemap: true
-slides_url: ''
+slides_url: 'https://speakerdeck.com/zanderle/javascript-for-python-developers'
 summary: ''
 title: JavaScript for Python Developers
 track: t0

--- a/_schedule/talks/2018-10-16-17-00-t0-normalize-until-it-hurts-denormalize-it.md
+++ b/_schedule/talks/2018-10-16-17-00-t0-normalize-until-it-hurts-denormalize-it.md
@@ -23,7 +23,7 @@ presenters:
 published: true
 room: 'Salon A-E'
 sitemap: true
-slides_url: ''
+slides_url: 'http://bit.ly/django-norm'
 summary: ''
 title: '"Normalize until it hurts; denormalize until it works" in Django'
 track: t0

--- a/_schedule/talks/2018-10-16-17-00-t1-we-are-3000-years-behind-let-s-talk.md
+++ b/_schedule/talks/2018-10-16-17-00-t1-we-are-3000-years-behind-let-s-talk.md
@@ -29,7 +29,7 @@ presenters:
 published: true
 room: 'Salon F-H'
 sitemap: true
-slides_url: ''
+slides_url: 'https://drive.google.com/file/d/10CxD7-N_7ttGF8Z2zkaiS5eZ1uidSchx/view'
 summary: ''
 title: 'We Are 3000 Years Behind: Let''s Talk About Engineering Ethics'
 track: t1

--- a/_schedule/talks/2018-10-17-10-05-keynote-with-mariatta-wijaya.md
+++ b/_schedule/talks/2018-10-17-10-05-keynote-with-mariatta-wijaya.md
@@ -18,6 +18,7 @@ presenters:
   website: https://mariatta.ca/
 room: Salon A-E
 sitemap: true
+slides_url: 'https://speakerdeck.com/mariatta/dont-be-a-robot-build-the-bot'
 talk_slot: full
 title: Keynote with Mariatta Wijaya
 video_url: null

--- a/_schedule/talks/2018-10-17-11-30-t0-django-rest-framework-moving-past-the-to.md
+++ b/_schedule/talks/2018-10-17-11-30-t0-django-rest-framework-moving-past-the-to.md
@@ -25,7 +25,7 @@ presenters:
 published: true
 room: 'Salon A-E'
 sitemap: true
-slides_url: ''
+slides_url: 'https://docs.google.com/presentation/d/1DpngY037NZqq2aelnM4czjgWIUh20tF5Q4jp3yOOHuU/edit'
 summary: ''
 title: 'Django REST Framework: Moving Past the Tutorial to Production'
 track: t0

--- a/_schedule/talks/2018-10-17-11-30-t2-anatomy-of-open-edx-a-modern-online-over.md
+++ b/_schedule/talks/2018-10-17-11-30-t2-anatomy-of-open-edx-a-modern-online-over.md
@@ -26,7 +26,7 @@ presenters:
 published: true
 room: 'Salon F-H'
 sitemap: true
-slides_url: ''
+slides_url: 'https://www.slideshare.net/nateaune/anatomy-of-open-edx-at-djangocon-2018-san-diego'
 summary: ''
 title: Anatomy of Open edX - a modern online learning platform serving over 35 million
   users

--- a/_schedule/talks/2018-10-17-14-20-t1-unique-ways-to-hack-into-a-python-web.md
+++ b/_schedule/talks/2018-10-17-14-20-t1-unique-ways-to-hack-into-a-python-web.md
@@ -28,7 +28,7 @@ presenters:
 published: true
 room: 'Salon F-H'
 sitemap: true
-slides_url: ''
+slides_url: 'https://www.slideshare.net/tilaknairmelpal/unique-waytohackintoapythonwebservice-119972991'
 summary: ''
 title: Unique ways to Hack into a Python Web Service
 track: t1

--- a/_schedule/talks/2018-10-17-15-10-t0-orm-the-sequel.md
+++ b/_schedule/talks/2018-10-17-15-10-t0-orm-the-sequel.md
@@ -28,7 +28,7 @@ presenters:
 published: true
 room: 'Salon A-E'
 sitemap: true
-slides_url: ''
+slides_url: 'https://glasnt.com/talks/2018_10_DjangoConUS_Emoji/assets/player/KeynoteDHTMLPlayer.html'
 summary: ''
 title: 'ORM: The Sequel'
 track: t0

--- a/_schedule/talks/2018-10-17-16-40-t1-real-life-accessibility-have-you-heard.md
+++ b/_schedule/talks/2018-10-17-16-40-t1-real-life-accessibility-have-you-heard.md
@@ -22,7 +22,7 @@ presenters:
 published: true
 room: 'Salon F-H'
 sitemap: true
-slides_url: ''
+slides_url: 'https://drive.google.com/file/d/1QhA-Yuw_ZJZEYwZayCcXa-PUQFK4oRe8/view'
 summary: ''
 title: 'Real Life Accessibility: Have you HEARD your site?'
 track: t1


### PR DESCRIPTION
A Twitter search of `#djangocon AND slides` proved quite fruitful, so I pulled what I could find from there into `slides_url` fields throughout the talk schedule.