### PR TITLE
start adding videos with CC

### DIFF
--- a/_schedule/talks/2018-10-15-09-40-keynote-with-chloe-condon.md
+++ b/_schedule/talks/2018-10-15-09-40-keynote-with-chloe-condon.md
@@ -19,7 +19,7 @@ room: Salon A-E
 sitemap: true
 talk_slot: full
 title: Keynote with Chloe Condon
-video_url: 'https://youtu.be/SUNLjbUQLrs'
+video_url: 'https://youtu.be/2D14UpKkPtI'
 ---
 
 Chloe's keynote will dive into why laughter, fun, and entertainment are valuable in the world of tech. Speaking from the experience of someone with a 4-year theatre degree who once played a talking crayon on stage (blue AND yellow -- she has a wide range), she'll dive into lessons learned from theatre applied to engineering.


### PR DESCRIPTION
The videos on YouTube are starting to be replaced with ones with Closed Captioning.

Here is the new one for the Keynote With Chloe Condon.

I intend on leaving this ticket open as other videos are replaced.   Unfortunately the new video's get new urls.  Which means the video on the existing talk for Ms Condon is broken.